### PR TITLE
Allow passing a parsed call to `s3_dispatch`

### DIFF
--- a/R/dispatch.R
+++ b/R/dispatch.R
@@ -20,8 +20,7 @@
 #'
 #' s3_dispatch(length(x1))
 #' s3_dispatch(length(x2))
-s3_dispatch <- function(call, env = parent.frame()) {
-  call <- substitute(call)
+s3_dispatch <- function(call = substitute(call), env = parent.frame()) {
   generic <- as.character(call[[1]])
   x <- eval(call[[2]], env)
 


### PR DESCRIPTION
In my case I have an already parsed call and want to know which method will be called.